### PR TITLE
fix: Enable `editUrl` in Docusaurus site configuration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,6 +35,8 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          editUrl:
+            'https://github.com/keptn-sandbox/new-keptn-docs-engine/edit/main/',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Fixes: #13
Related: https://github.com/keptn/keptn.github.io/issues/994
