### PR TITLE
feat: Add Prettier GitHub Action support to format docs

### DIFF
--- a/.github/workflows/prettier-format.yaml
+++ b/.github/workflows/prettier-format.yaml
@@ -1,0 +1,21 @@
+name: Prettier check
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - run: yarn install --frozen-lockfile
+      - run: yarn format
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: Apply formatting changes
+          branch: ${{ github.head_ref }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "format": "prettier --write '**/*.{css,html,js,json,jsx,md,mdx,ts,tsx,yaml,yml}'",
+    "format": "prettier --write 'docs/*.{md,mdx}'",
     "lint": "eslint . --ext .ts --ext .js --ext .jsx --ext .tsx",
     "lint:fix": "yarn run lint --fix"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "format": "prettier --write 'docs/*.{md,mdx}'",
+    "format": "prettier --write 'docs/**/*.{md,mdx}'",
     "lint": "eslint . --ext .ts --ext .js --ext .jsx --ext .tsx",
     "lint:fix": "yarn run lint --fix"
   },


### PR DESCRIPTION
Fixes: #23
Related: keptn/keptn.github.io#994

> Currently, we will run the prettier checks for `docs/**/*.{md,mdx}` files only because mentors suggested making the PR as PoC.
