### PR TITLE
feat: Add broken link checker

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link-report.md
+++ b/.github/ISSUE_TEMPLATE/broken-link-report.md
@@ -1,0 +1,8 @@
+---
+name: Broken link report
+about: Automated issue template for reporting link checker fails
+title: Failing link check ({{ date | date('dddd, MMMM Do') }})
+labels: automated issue, bug, documentation, broken links
+---
+
+The broken link check failed. Check [the workflow logs](https://https://github.com/keptn-sandbox/new-keptn-docs-engine/actions/workflows/daily-link-checker.yaml) to identify the failing links.

--- a/.github/workflows/daily-link-checker.yaml
+++ b/.github/workflows/daily-link-checker.yaml
@@ -1,0 +1,39 @@
+name: Check all markdown links daily
+
+on:
+  schedule:
+    - cron: '0 23 * * *'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from /docs including all subfolders
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/markdown.links.config.json'
+          folder-path: 'docs/'
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from the root but ignores subfolders
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/markdown.links.config.json'
+          max-depth: 0
+
+      # Automatically create an issue if there are broken links
+      - name: Create issue
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@9e6213aec58987fa7d2f4deb8b256b99e63107a2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/broken-link-report.md

--- a/.github/workflows/markdown.links.config.json
+++ b/.github/workflows/markdown.links.config.json
@@ -1,0 +1,13 @@
+{
+    "replacementPatterns": [
+      {
+        "pattern": "^/",
+        "replacement": "https://keptn-experimental-docs-site.netlify.app/"
+      }
+    ],
+    "ignorePatterns": [
+      {
+        "pattern": "^https?://localhost"
+      }
+    ]
+}


### PR DESCRIPTION
Fixes: #27
Related: keptn/keptn.github.io#994

#### Issue template for the broken link will look like this

<img width="1239" alt="Screenshot 2022-09-06 at 6 51 11 AM" src="https://user-images.githubusercontent.com/42106787/188575767-424b86b5-eca3-458f-b80d-db7f9cd91187.png">

#### Report for the broken links will look like this

<img width="954" alt="Screenshot 2022-09-06 at 6 51 51 AM" src="https://user-images.githubusercontent.com/42106787/188575782-897e8f47-9f64-47b6-b6d6-e65fa2487d3d.png">

> `.github/workflows/markdown.links.config.json` file is use for specifying a custom [configuration file](https://github.com/tcort/markdown-link-check#config-file-format) for markdown-link-check. You can use it to remove false positives by specifying replacement patterns.
